### PR TITLE
Bring back `noReferences`, `maybeReferenced`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-11-28 Ivan Krylov <krylov.r00t@gmail.com>
+
+	* inst/include/tidy/internals.h: Reintroduced noReferences,
+	maybeReferenced using a different R API function
+
 2025-11-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -10,6 +10,8 @@
     \item A badge for r-universe has been added to the README.md
     \item The vignette is now served via GitHub Pages and that version is
     referenced in the README.
+    \item Reintroduced \code{noReferences}, \code{maybeReferenced} using
+    a different R API function (\ghpr{5}).
   }
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -10,8 +10,6 @@
     \item A badge for r-universe has been added to the README.md
     \item The vignette is now served via GitHub Pages and that version is
     referenced in the README.
-    \item Reintroduced \code{noReferences}, \code{maybeReferenced} using
-    a different R API function (\ghpr{5}).
   }
 }
 

--- a/inst/include/tidy/internals.h
+++ b/inst/include/tidy/internals.h
@@ -66,8 +66,8 @@ namespace R {                   // we remain all tidied up in a namespace
 
     inline bool maybeShared(SEXP x)     { return(MAYBE_SHARED(x));  }
     inline bool notShared(SEXP x)       { return(!maybeShared(x));  }
-    //inline bool noReferences(SEXP x)    { return(REFCNT(x) == 0);   }
-    //inline bool maybeReferenced(SEXP x) { return(!noReferences(x)); }
+    inline bool noReferences(SEXP x)    { return(NO_REFERENCES(x)); }
+    inline bool maybeReferenced(SEXP x) { return(!noReferences(x)); }
 
     inline int length(SEXP x)           { return(LENGTH(x));        }
     inline R_xlen_t xlength(SEXP x)     { return(XLENGTH(x));       }


### PR DESCRIPTION
I don't have a strong opinion regarding this, but if you'd like to, you can make these functions use the [`NO_REFERENCES()`](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#index-NO_005fREFERENCES-1) entry point introduced in R-3.1.0.